### PR TITLE
Default the output format to circom variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ A successful run will output logging info ***similar*** to the following (note t
 # final unknown set #<set: 1 2 3>.
 # weak uniqueness: unsafe.
 # counter-example:
-  #hash((one . 1) (p . 0) (ps1 . 21888242871839275222246405745257275088548364400416034343698204186575808495616) (ps2 . 21888242871839275222246405745257275088548364400416034343698204186575808495615) (ps3 . 21888242871839275222246405745257275088548364400416034343698204186575808495614) (ps4 . 21888242871839275222246405745257275088548364400416034343698204186575808495613) (ps5 . 21888242871839275222246405745257275088548364400416034343698204186575808495612) (x0 . 0) (x1 . 1) (x2 . 0) (x3 . 1) (x4 . 0) (y1 . 0) (y2 . 0) (y3 . 0) (zero . 0)).
+  #hash((m1.main.inp . 0) (m1.main.out[0] . 0) (m1.main.out[1] . 0) (m1.main.success . 0) (m2.main.out[0] . 1) (m2.main.out[1] . 0) (m2.main.success . 1)).
 ```
 
 If you see this, it means the environment that you are operating on is configured successfully.

--- a/picus-dpvl-uniqueness.rkt
+++ b/picus-dpvl-uniqueness.rkt
@@ -23,7 +23,7 @@
 (define arg-slv #t)
 (define arg-smt #f)
 (define arg-weak #f)
-(define arg-map #f)
+(define arg-map #t)
 (command-line
     #:once-each
     [("--r1cs") p-r1cs "path to target r1cs"
@@ -61,8 +61,8 @@
     [("--weak") "only check weak safety, not strong safety  (default: false)"
         (set! arg-weak #t)
     ]
-    [("--map") "map the r1cs signals of model to its circom variable (default: true)"
-        (set! arg-map #t)
+    [("--raw-output") "show the raw r1cs signals (default: false / map r1cs signals to circom variables)"
+        (set! arg-map #f)
     ]
 )
 (printf "# r1cs file: ~a\n" arg-r1cs)


### PR DESCRIPTION
Prior this commit, the counterexample output format is defaulted to r1cs signals (although the help page incorrectly says otherwise). This commit fixes the help page and at the same time switches the default format to circom variables, since the format is more readable for clients. The flag `--raw-output` can still be used to view the r1cs signals, which could be useful for debugging.