### PR TITLE
Restructure counterexample output format for readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,11 @@ A successful run will output logging info ***similar*** to the following (note t
 # solver: cvc5
 # selector: counter
 # precondition: ()
-# propagation: #t
+# propagation on: #t
+# solver on: #t
 # smt: #f
 # weak: #t
-# map: #f
+# verbose: 0
 # number of wires: 5
 # number of constraints: 4
 # field size (how many bytes): 32
@@ -110,8 +111,17 @@ A successful run will output logging info ***similar*** to the following (note t
   # checking: (x1 y1), sat.
 # final unknown set #<set: 1 2 3>.
 # weak uniqueness: unsafe.
-# counter-example:
-  #hash((m1.main.inp . 0) (m1.main.out[0] . 0) (m1.main.out[1] . 0) (m1.main.success . 0) (m2.main.out[0] . 1) (m2.main.out[1] . 0) (m2.main.success . 1)).
+# ./benchmarks/circomlib-cff5ab6/Decoder@multiplexer.r1cs is underconstrained. Below is a counterexample:
+  # inputs:
+    # m1.main.inp: 0
+  # first possible outputs:
+    # m1.main.out[0]: 0
+    # m1.main.out[1]: 0
+    # m1.main.success: 0
+  # second possible outputs:
+    # m2.main.out[0]: 1
+    # m2.main.out[1]: 0
+    # m2.main.success: 1
 ```
 
 If you see this, it means the environment that you are operating on is configured successfully.

--- a/ansi.rkt
+++ b/ansi.rkt
@@ -1,0 +1,9 @@
+#lang racket
+
+(provide highlight)
+
+(define (ansi-code code)
+  (format "~a~a" (integer->char #x1b) code))
+
+(define (highlight s)
+  (~a (ansi-code "[33m") s (ansi-code "[0m")))


### PR DESCRIPTION
This commit adds a flag `--verbose` for verbose level, which supplants the flag `--raw-output` (or, previously, `--map`).
- When the verbose level is 0 (not verbose), the output is in the circom variable format.
- When the verbose level is 1, the output is a mixed between the circom variable format and the r1cs signal format, where we prefer the circom variable format whenever possible.
- When the verbose level is 2, the output is always in the r1cs signal format.

For `--verbose 0`, the output now has three sections: inputs, first possible outputs, and second possible outputs.

For other verbosity level, there could be four sections. The extra section is "other bindings".

Entries that are different in the first possible outputs and second possible outputs are further highlighted with ANSI escape sequence.

Examples:

With `--verbose 0`:

```
  # inputs:
    # m1.main.inp: 0
  # first possible outputs:
    # m1.main.out[0]: 0
    # m1.main.out[1]: 0
    # m1.main.success: 0
  # second possible outputs:
    # m2.main.out[0]: 1
    # m2.main.out[1]: 0
    # m2.main.success: 1
```

With `--verbose 1`:

```
  # inputs:
    # m1.main.inp: 0
  # first possible outputs:
    # m1.main.out[0]: 0
    # m1.main.out[1]: 0
    # m1.main.success: 0
  # second possible outputs:
    # m2.main.out[0]: 1
    # m2.main.out[1]: 0
    # m2.main.success: 1
  # other bindings:
    # one: 1
    # p: 21888242871839275222246405745257275088548364400416034343698204186575808495617
    # ps1: 21888242871839275222246405745257275088548364400416034343698204186575808495616
    # ps2: 21888242871839275222246405745257275088548364400416034343698204186575808495615
    # ps3: 21888242871839275222246405745257275088548364400416034343698204186575808495614
    # ps4: 21888242871839275222246405745257275088548364400416034343698204186575808495613
    # ps5: 21888242871839275222246405745257275088548364400416034343698204186575808495612
    # zero: 0
```

With `--verbose 2`

```
  # inputs:
    # x4: 0
  # first possible outputs:
    # x1: 0
    # x2: 0
    # x3: 0
  # second possible outputs:
    # y1: 1
    # y2: 0
    # y3: 1
  # other bindings:
    # one: 1
    # p: 21888242871839275222246405745257275088548364400416034343698204186575808495617
    # ps1: 21888242871839275222246405745257275088548364400416034343698204186575808495616
    # ps2: 21888242871839275222246405745257275088548364400416034343698204186575808495615
    # ps3: 21888242871839275222246405745257275088548364400416034343698204186575808495614
    # ps4: 21888242871839275222246405745257275088548364400416034343698204186575808495613
    # ps5: 21888242871839275222246405745257275088548364400416034343698204186575808495612
    # zero: 0
```