### PR TITLE
solvers: close ports properly

### DIFF
--- a/picus/solvers/cvc4-solver.rkt
+++ b/picus/solvers/cvc4-solver.rkt
@@ -44,6 +44,9 @@
         [(not eres)
             ; need to kill the process
             (subprocess-kill sp #t)
+            (close-input-port out)
+            (close-output-port in)
+            (close-input-port err)
             (cons 'timeout "")
         ]
         [else

--- a/picus/solvers/cvc5-solver.rkt
+++ b/picus/solvers/cvc5-solver.rkt
@@ -45,6 +45,9 @@
         [(not eres)
             ; need to kill the process
             (subprocess-kill sp #t)
+            (close-input-port out)
+            (close-output-port in)
+            (close-input-port err)
             (cons 'timeout "")
         ]
         [else

--- a/picus/solvers/z3-solver.rkt
+++ b/picus/solvers/z3-solver.rkt
@@ -45,6 +45,9 @@
         [(not eres)
             ; need to kill the process
             (subprocess-kill sp #t)
+            (close-input-port out)
+            (close-output-port in)
+            (close-input-port err)
             (cons 'timeout "")
         ]
         [else


### PR DESCRIPTION
On benchmarks that are not quickly solved, I keep encountering the error:

  subprocess: process creation failed
    system error: Too many open files; errno=24

This is because ports are not properly closed when the corresponding process is killed. This commit fixes the problem.

In the long run, it would be better to restructure these modules to share common code, so that the fix can be done at a single place.