### PR TITLE
fix: make parser significantly more efficient

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -56,6 +56,17 @@ jobs:
         run: |
           grep "^# weak uniqueness: unsafe\.$" ./result.out
 
+  racket-test:
+    runs-on: ubuntu-latest
+    container:
+      image: veridise/picus:git-latest
+    env:
+      PLTADDONDIR: /root/.local/share/racket/
+    steps:
+      - uses: actions/checkout@v1
+      - name: run tests
+        run: raco test ./tests
+
   publish-docker:
     needs: [test-solve-with-z3, test-solve-with-cvc5]
     name: "Publish Docker image to DockerHub"

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ benchmarks/**/*.json
 benchmarks/**/*.sym
 benchmarks/**/*.r1cs
 benchmarks/**/*.log
+!benchmarks/r1cs/*.r1cs
 logs/**/*.log
 .ipynb_checkpoints/
 

--- a/tests/efficient-parsing.rkt
+++ b/tests/efficient-parsing.rkt
@@ -1,0 +1,9 @@
+#lang racket/base
+
+(module+ test
+  (require racket/sandbox
+           (prefix-in r1cs: "../picus/r1cs/r1cs-grammar.rkt"))
+
+  ;; read this within 30s or error
+  (with-limits 30 #f
+    (void (r1cs:read-r1cs "../benchmarks/r1cs/TreeHasher.r1cs"))))


### PR DESCRIPTION
Prior this commit, `read-r1cs` copied bytes in the file over and over again in a hot loop, causing the time complexity to be quadratic. This commit switches to use index-based access in the hot loop instead, resulting in a large performance improvement.
The benchmark file that accompanies this fix took 30 minutes to successfully parse (according to @shankarapailoor). This commit reduces the parsing time to 2 seconds.

It should be noted that not all bytes copying is avoided, since bytes copying outside the hot loop, although not ideal, does not really impact the performance.