### PR TITLE
fix: reimplement linear lemma to make it more efficient

### DIFF
--- a/picus/algorithms/lemmas/linear-lemma.rkt
+++ b/picus/algorithms/lemmas/linear-lemma.rkt
@@ -3,110 +3,93 @@
 ;   if c * x = (unique), and c != 0 is a constant, then x is also uniquely determined
 ; note that this lemma doesn't apply to the following:
 ;   c * x0 * x1 = (unique), and c * x0 != 0
-(require
-    (prefix-in r1cs: "../../r1cs/r1cs-grammar.rkt")
-)
-(provide (rename-out
-    [compute-cdmap compute-cdmap]
-    [compute-rcdmap compute-rcdmap]
-    [apply-lemma apply-lemma]
-))
+(require (prefix-in r1cs: "../../r1cs/r1cs-grammar.rkt")
+         "../../../verbose.rkt")
+(provide compute-linear-clauses
+         compute-weight-map
+         apply-lemma)
 
-; global variable, cached rcdmap
-; store and ref with tag (key)
-(define :cached-rcdmaps (make-hash))
-
-; get constraint dependency map
+; get constraint dependency clauses
 ; input is the *normalized main constraint part* of r1cs ast
 ;   - main constraints is the `cnsts part (r1cs:rcmds) from parse-r1cs
-; returns a map of:
-;   - key: index of a variable
-;   - val: list of sets of variables
-; meaning: if a key wants to be determined as unique,
-;          one of the sets from val should be completely determined
+;
+; returns a (listof (cons/c mutable-set? mutable-set?)):
+;   where each pair item in the list corresponds to a constraint.
+;   The pair consists of:
+;   - deducible-vars: a set of variables that can be determined as unique in the current constraint
+;   - nonlinear-vars: a set of variables that are non-linear in the current constraint
+;
+; meaning:
+;   in a clause, to determine that a var in deducible-vars is unique,
+;   all nonlinear-vars and other deducible-vars must be determined unique.
+;
 ; construction rules (++terms):
 ;   - only non-non-linear (YES, no typo here) variable can be determined (put to key)
 ;     because for x*y=k, x can't be guaranteed to be unique,
 ;     even if knowing y and k (due to field mul)
-(define (compute-cdmap arg-cnsts [arg-indexonly #f])
-    (define res (make-hash))
-    ; for every single constraint
-    (for ([p (r1cs:rcmds-vs arg-cnsts)])
-        (define all-vars (r1cs:get-assert-variables p arg-indexonly))
-        (define nonlinear-vars (r1cs:get-assert-variables/nonlinear p arg-indexonly))
-        ; (note) you can't use linears directly, because one var could be both linear and non-linear
-        ;        in this case, it's still non-linear in the current constraint
-        (define deducible-vars (set-subtract all-vars nonlinear-vars))
-        (for ([key deducible-vars])
-            (when (not (hash-has-key? res key)) (hash-set! res key (list )))
-            (hash-set! res key (cons (set-subtract all-vars (list->set (list key))) (hash-ref res key)))
-        )
-    )
-    res
-)
+(define (compute-linear-clauses arg-cnsts [arg-indexonly #f])
+  (for/list ([p (r1cs:rcmds-vs arg-cnsts)]
+             #:do [(define all-vars (r1cs:get-assert-variables p arg-indexonly))
+                   (define nonlinear-vars (r1cs:get-assert-variables/nonlinear p arg-indexonly))
+                   ; (note) you can't use linears directly, because one var could be both linear and non-linear
+                   ;        in this case, it's still non-linear in the current constraint
+                   (define deducible-vars (set-subtract all-vars nonlinear-vars))]
+             #:unless (set-empty? deducible-vars))
+    (cons (set-copy deducible-vars) (set-copy nonlinear-vars))))
 
-; get a reversed cdmap
-;   - arg-indexonly: whether to extract the indices instead of keeping the full variable name
-; example output:
-;   #<set: x10> => #<set: x4>
-;   #<set: x6 x14 x12 x11> => #<set: x13>
-;   #<set: x5 x14 x12> => #<set: x11>
-;   #<set: x5 x14 x11> => #<set: x12>
-;   #<set: x2> => #<set: x6>
-;   #<set: x8> => #<set: x4>
-;   #<set: x1> => #<set: x5>
-;   #<set: x9> => #<set: x3>
-;   #<set: x7> => #<set: x3>
-(define (compute-rcdmap arg-cnsts [arg-indexonly #f] [arg-tag 'default])
-    (cond
-        ; there's a cached version for the given tag, no more computation, just fetch & return
-        [(hash-has-key? :cached-rcdmaps arg-tag) (hash-ref :cached-rcdmaps arg-tag)]
-        ; no cached version, compute, cache and return
-        [else
-            (define res (compute-cdmap arg-cnsts arg-indexonly))
-            (define new-res (make-hash))
-            (for ([key (hash-keys res)])
-                (define vals (hash-ref res key))
-                (for ([val vals])
-                    (when (not (hash-has-key? new-res val)) (hash-set! new-res val (list )))
-                    (hash-set! new-res val (cons key (hash-ref new-res val)))
-                )
-            )
-            ; make immutable
-            (for ([key (hash-keys new-res)])
-                (hash-set! new-res key (list->set (hash-ref new-res key)))
-            )
-            ; store to cache
-            (hash-set! :cached-rcdmaps arg-tag new-res)
-            ; return
-            new-res
-        ]
-    )
-)
+(define (compute-weight-map linear-clauses)
+  (define res (make-hash))
+  (for ([clause (in-list linear-clauses)])
+    (match-define (cons deducible-vars nonlinear-vars) clause)
+    ;; NOTE(sorawee): I think this is not optimal. We should revisit this.
+    (define len-deducible (set-count deducible-vars))
+    (for ([var (in-set deducible-vars)])
+      (hash-update! res var (λ (old) (+ old len-deducible -1)) 0))
+    (for ([var (in-set nonlinear-vars)])
+      (hash-update! res var (λ (old) (+ old len-deducible)) 0)))
+  res)
 
 ; recursively apply linear lemma
-(define (apply-lemma rcdmap ks us)
-    (printf "  # propagation (linear lemma): ")
-    (define new-ks (list->set (set->list ks))) ; (fixme) do this to copy into a mutable set, required by set-* operations
-    (define new-us (list->set (set->list us))) ; (fixme) same as above
-    (define rec? #f) ; whether propagate should be called again
-    (for* ([key (hash-keys rcdmap)])
-        (when (set-empty? (set-subtract key ks))
-            ; all ks are in key, propagate
-            (set! new-ks (set-union new-ks (hash-ref rcdmap key)))
-            (set! new-us (set-subtract new-us (hash-ref rcdmap key)))
-        )
-    )
-    (let ([s0 (set-subtract new-ks ks)])
-        (if (set-empty? s0)
-            (printf "none.\n")
-            (printf "~a added.\n" s0)
-        )
-    )
-    (if (= (set-count ks) (set-count new-ks))
-        ; no updates, return now
-        (values new-ks new-us)
-        ; has updates, call again
-        (apply-lemma rcdmap new-ks new-us)
-    )
-)
+(define (apply-lemma linear-clauses ks us)
+  (printf "  # propagation (linear lemma):\n")
+  ;; add a dummy element -1 so that working-set is not initially empty
+  ;; (since being empty is the condition for termination)
+  (let loop ([linear-clauses linear-clauses]
+             [inferred (set)]
+             [working-set (set-add ks -1)])
+    (cond
+      [(set-empty? working-set)
+       (values linear-clauses (set-union ks inferred) (set-subtract us inferred))]
+      [else
+       ;; remove all known variables from linear-clauses
+       (for ([pair (in-list linear-clauses)])
+         (match-define (cons deducible-vars nonlinear-vars) pair)
+         ;; make a copy via set->list so that we can remove items froim the set
+         ;; while iterating on it.
+         (for ([v (in-list (set->list deducible-vars))]
+               #:when (set-member? working-set v))
+           (set-remove! deducible-vars v))
+
+         (for ([v (in-list (set->list nonlinear-vars))]
+               #:when (set-member? working-set v))
+           (set-remove! nonlinear-vars v)))
+
+       ;; filter out useless clauses
+       (define new-linear-clauses
+         (for/list ([pair (in-list linear-clauses)]
+                   #:do [(match-define (cons deducible-vars _) pair)]
+                   #:unless (set-empty? deducible-vars))
+           pair))
+
+       ;; NOTE: possible optimization: remove these entries right away,
+       ;; since the next iteration would remove them anyway.
+       (define Δinferred
+         (for/set ([pair (in-list new-linear-clauses)]
+                   #:do [(match-define (cons deducible-vars nonlinear-vars) pair)]
+                   #:when (= 1 (set-count deducible-vars))
+                   #:when (set-empty? nonlinear-vars))
+           (set-first deducible-vars)))
+
+       (vprintf "    # ~e added.\n" Δinferred)
+
+       (loop new-linear-clauses (set-union inferred Δinferred) Δinferred)])))

--- a/picus/algorithms/selectors/counter-selector.rkt
+++ b/picus/algorithms/selectors/counter-selector.rkt
@@ -1,9 +1,7 @@
 #lang racket
-(provide (rename-out
-    [apply-selector apply-selector]
-    [selector-init selector-init]
-    [selector-feedback selector-feedback]
-))
+(provide apply-selector
+         selector-init
+         selector-feedback)
 
 ; shared stateful variables and methods
 ; signal weights
@@ -16,53 +14,31 @@
 
 ; =======================
 ; counter select strategy
-; choose the signal that appears the most in the keys of rcdmap
+; choose the signal that "contributes" the most to determine a uniqueness of
+; other signals.
 ; i.e. the most "critical" one for propagation
-(define state-rcdkey-counter null) ; cached rcdkey counter, key: index, val: count
-; key first select: select the key with higher appearance in rcdmap
-(define (apply-selector uspool cntx)
-    ; check for existence of counter
-    (when (null? state-rcdkey-counter)
-        ; counter not created yet, create one
-        (define tmp-counter (make-hash))
-        (for ([keys (hash-keys (hash-ref cntx 'rcdmap))])
-            (for ([key keys])
-                (when (not (hash-has-key? tmp-counter key)) (hash-set! tmp-counter key 0))
-                (hash-set! tmp-counter key (+ 1 (hash-ref tmp-counter key)))
-            )
-        )
-        (set! state-rcdkey-counter tmp-counter)
-    )
-    ; copy the counter and filter out non uspool ones
-    (define tmp-counter (make-hash))
-    (for ([key (hash-keys state-rcdkey-counter)])
-        (when (set-member? uspool key)
-            ; copy and calculate the weight
-            (hash-set! tmp-counter key
-                (+ (hash-ref state-rcdkey-counter key) (signal-weights-ref key))
-            )
-        )
-    )
-    ; add remaining uspool ones into the counter
-    (for ([key uspool])
-        (when (not (hash-has-key? tmp-counter key)) (hash-set! tmp-counter key 0)))
-    ; sort and pick
-    (define p0 (argmax cdr (hash->list tmp-counter)))
-    ; return
-    (car p0)
-)
+(define (apply-selector uspool weight-map)
+  ; copy the counter and filter out non uspool ones
+  (define tmp-counter (make-hash))
+  (for ([(var counter) (in-hash weight-map)]
+        #:when (set-member? uspool var))
+    (hash-set! tmp-counter var (+ counter (signal-weights-ref var))))
+  ; add remaining uspool ones into the counter
+  (for ([var uspool]
+        #:unless (hash-has-key? tmp-counter var))
+    (hash-set! tmp-counter var 0))
+  ; sort and pick
+  (car (argmax cdr (hash->list tmp-counter))))
 
 (define (selector-init nwires)
-    (signal-weights-reset!)
-    (for ([key (range nwires)]) (signal-weights-set! key 0))
-)
+  (signal-weights-reset!)
+  (for ([key (range nwires)])
+    (signal-weights-set! key 0)))
 
 ; adjust internal states according to the solver result
 (define (selector-feedback sid act)
-    (cond
-        ; decrease the weight of the selected id since it's not solved
-        [(equal? 'skip act) (signal-weights-dec! sid 1)]
-        ; otherwise do nothing
-        [else (void)]
-    )
-)
+  (cond
+    ; decrease the weight of the selected id since it's not solved
+    [(equal? 'skip act) (signal-weights-dec! sid 1)]
+    ; otherwise do nothing
+    [else (void)]))


### PR DESCRIPTION
Prior this commit, linear lemma depends on the CDMAP and RCDMAP procedures.

Let's say that constraint i involves variables Xi and Yi, where Xi variables are the linear part, and Yi variables are the non-linear parts. That is to say, the input follows this format:

  Constraint 1: X11 X12 ... Y11 Y12 ...
  Constraint 2: X21 X22 ... Y21 Y22 ...
  ...
  Constraint n: Xn1 Xn2 ... Yn1 Yn2 ...

which is of size O(sum |Xi| + sum |Yi|).

The CDMAP procedure produces a map from a variable to a list of list of variables. Meaning: a key can be uniquely determined if one of the list of variables are all uniquely determined.

Thus, CDMAP produces a data of size O(sum { |Xi| (|Xi| + |Yi|) }) as the output (where values of the same key are grouped together)

  X11: X12 X13 ... Y11 Y12 ...
  X12: X11 X13 ... Y11 Y12 ...
  ...
  X1k: X11 X12 ... Y11 Y12 ...

  X21: X22 X23 ... Y21 Y22 ...
  X22: X21 X23 ... Y21 Y22 ...
  ...

  .....

  Xn1: Xn2 Xn3 ... Yn1 Yn2 ...
  Xn2: Xn1 Xn3 ... Yn1 Yn2 ...
  ...
  Xnk: Xn1 Xn2 ... Yn1 Yn2 ...

Often, some clauses might have O(n) variables, making the size O(n^3) if the table is dense, or O(n^2) if the table is sparse.

The RCDMAP procedure essentially consumes a map that CDMAP procedure outputs, and produces the inverse of that map, with duplicate keys of the input map grouped together. The size is thus the same.

RCDMAP is also used in the counter selector. E.g., given:

  1 2 3 | 4 6
  1 3 5 | 4 6

Then CDMAP produces:

  1: [2 3 4 6, 3 5 4 6]
  2: [1 3 4 6]
  3: [1 2 4 6, 1 5 4 6]
  5: [1 3 4 6]

And RCDMAP produces:

  1 3 4 6: [2, 5]
  2 3 4 6: [1]
  3 5 4 6: [1]
  1 2 4 6: [3]
  1 5 4 6: [3]

The counter selector counts that 5 occurs 2 times in the keys, so it is weighted 2. 6, by contrast, occurs 5 times, so it is weighted 5.

-------------------------------------------------------------------

This commit aims to improve the performance by avoiding blowing up the data size beyond linear. It also aims to preserve the existing behavior as much as possible.

This is done by removing the CDMAP and RCDMAP procedures, and instead employing the straightforward encoding:

  X11 X12 ... | Y11 Y12 ...
  X21 X22 ... | Y21 Y22 ...
  ...
  Xn1 Xn2 ... | Yn1 Yn2 ...

which has the linear size.

When a variable is uniquely determined, we simply cross it off from the above table. A variable becomes propagable when it's the only one left in the linear part, and the non-linear part is empty.

For counter selector, we produce the counter without expanding the encoding beyond linear size. This can be done by simple multiplication: in (Xi, Yi), each variable in Xi contributes to other variables in Xi exactly |Xi|-1 times (not counting itself) and each variable in Yi contributes to other variables in Xi exactly |Xi| times.

The results are not the same, however. Consider the earlier concrete example:

Our encoding:

  1 2 3 | 4 6
  1 3 5 | 4 6

RCDMAP:
  1 3 4 6: [2, 5]
  2 3 4 6: [1]
  3 5 4 6: [1]
  1 2 4 6: [3]
  1 5 4 6: [3]

The weights of 5 in both our encoding and RCDMAP agree: 2. However, the weights of 6 do not agree.

  Our encoding produces weight 6.
  RCDMAP produces weight 5.

Arguably, our weight is more "correct", because it takes the value part into account. I.e., in "1 3 4 6: [2, 5]", 6 contributes twice (2 once and 5 once), so it should be counted twice.

Separately, I also believe that the counter selector is not ideal, and plan to revamp the strategy soon, so the discrepancies will not matter anyway.

-------------------------------------------------------------------

The large benchmark was stuck at linear lemma prior this commit. It now was not stuck at this stage.