### PR TITLE
ci: fix mistakes from wrong compilation flag + add even more tests

### DIFF
--- a/tests/circomlib-test.rkt
+++ b/tests/circomlib-test.rkt
@@ -39,8 +39,8 @@
   (check-result "BabyAdd@babyjub" 'unknown)
   (check-result "BabyDbl@babyjub" 'safe)
 
-  ;; NOTE: BabyDbl@babyjub timeouted
-  #;(check-result "BabyDbl@babyjub" '???)
+  ;; NOTE: BabyPbk@babyjub timeouted
+  #;(check-result "BabyPbk@babyjub" '???)
 
   (check-result "BinSub@binsub" 'safe)
   (check-result "BinSum@binsum" 'safe)
@@ -49,19 +49,13 @@
   ;; but the basis lemma fix made it unknown
   (check-result "BitElementMulAny@escalarmulany" 'unknown)
 
-  ;; NOTE: BitElementMulAny@escalarmulany was safe,
-  ;; but the basis lemma fix made it timeouted
-  #;(check-result "Bits2Num_strict@bitify" 'safe)
-
+  (check-result "Bits2Num_strict@bitify" 'safe)
   (check-result "Bits2Num@bitify" 'safe)
 
   ;; NOTE: Bits2Point_Strict@pointbits timeouted
   #;(check-result "Bits2Point_Strict@pointbits" '???)
 
-  ;; NOTE: CompConstant@compconstant was safe,
-  ;; but the basis lemma fix made it timeouted
-  #;(check-result "CompConstant@compconstant" 'safe)
-
+  (check-result "CompConstant@compconstant" 'safe)
   (check-result "Decoder@multiplexer" 'unsafe)
   (check-result "Edwards2Montgomery@montgomery" 'unsafe)
 
@@ -69,4 +63,62 @@
   ;; but it takes 100s to run, so don't run it here.
   #;(check-result "EscalarMulAny@escalarmulany" 'unknown)
 
-  (check-result "EscalarProduct@multiplexer" 'safe))
+  (check-result "EscalarProduct@multiplexer" 'safe)
+  (check-result "GreaterEqThan@comparators" 'safe)
+  (check-result "GreaterThan@comparators" 'safe)
+  (check-result "IsEqual@comparators" 'safe)
+  (check-result "IsZero@comparators" 'safe)
+  (check-result "LessEqThan@comparators" 'safe)
+  (check-result "LessThan@comparators" 'safe)
+  (check-result "MiMC7@mimc" 'safe)
+  (check-result "MiMCFeistel@mimcsponge" 'safe)
+  (check-result "MiMCSponge@mimcsponge" 'safe)
+  (check-result "Montgomery2Edwards@montgomery" 'unsafe)
+  (check-result "MontgomeryAdd@montgomery" 'unsafe)
+  (check-result "MontgomeryDouble@montgomery" 'unsafe)
+  (check-result "MultiAND@gates" 'safe)
+  (check-result "MultiMiMC7@mimc" 'safe)
+  (check-result "MultiMux1@mux1" 'safe)
+  (check-result "MultiMux2@mux2" 'safe)
+  (check-result "MultiMux3@mux3" 'safe)
+  (check-result "MultiMux4@mux4" 'safe)
+  (check-result "Multiplexer@multiplexer" 'safe)
+  (check-result "Multiplexor2@escalarmulany" 'safe)
+  (check-result "Mux1@mux1" 'safe)
+  (check-result "Mux2@mux2" 'safe)
+  (check-result "Mux3@mux3" 'safe)
+  (check-result "Mux4@mux4" 'safe)
+  (check-result "NAND@gates" 'safe)
+  (check-result "NOR@gates" 'safe)
+  (check-result "NOT@gates" 'safe)
+
+  ;; NOTE: Num2Bits_strict@bitify was safe,
+  ;; but the basis lemma fix made it timeouted
+  #;(check-result "Num2Bits_strict@bitify" 'safe)
+
+  (check-result "Num2Bits@bitify" 'safe)
+  (check-result "Num2BitsNeg@bitify" 'safe)
+  (check-result "OR@gates" 'safe)
+  (check-result "Pedersen@pedersen_old" 'safe)
+  (check-result "Pedersen@pedersen" 'unknown)
+
+  ;; NOTE: Point2Bits_Strict@pointbits was safe,
+  ;; but the basis lemma fix made it timeouted
+  #;(check-result "Point2Bits_Strict@pointbits" 'safe)
+
+  (check-result "Poseidon@poseidon" 'safe)
+
+  ;; NOTE: Segment@pedersen, SegmentMulAny@escalarmulany, SegmentMulFix@escalarmulfix timeouted
+  #;(check-result "Segment@pedersen" '???)
+  #;(check-result "SegmentMulAny@escalarmulany" '???)
+  #;(check-result "SegmentMulFix@escalarmulfix" '???)
+
+  (check-result "Sigma@poseidon" 'safe)
+  (check-result "Sign@sign" 'safe)
+  (check-result "Switcher@switcher" 'safe)
+
+  ;; NOTE: Window4@pedersen, WindowMulFix@escalarmulfix timeouted
+  #;(check-result "Window4@pedersen" '???)
+  #;(check-result "WindowMulFix@escalarmulfix" '???)
+
+  (check-result "XOR@gates" 'safe))


### PR DESCRIPTION
PR #16 incorrectly concluded the expectation of some tests because I ran them with different optimization flag. The commit fixes the issue and add all other applicable tests in circomlib. These tests take less than 5 minutes to run in total, so that's not too long to run as a part of CI.