### PR TITLE
fix: compute unknown set correctly

### DIFF
--- a/picus/algorithms/lemmas/basis2-lemma.rkt
+++ b/picus/algorithms/lemmas/basis2-lemma.rkt
@@ -185,7 +185,7 @@
                         ; yes it's unique, then add all basis signals to known set
                         (begin
                             (set! tmp-ks (set-union tmp-ks (list->set siglist)))
-                            (set! tmp-us (set-remove tmp-us (list->set siglist)))
+                            (set! tmp-us (set-subtract tmp-us (list->set siglist)))
                             ; (when (equal? x0 "x2059")
                             ;     (printf "succeed.\n")
                             ;     (printf "old ks: ~a\n" ks)


### PR DESCRIPTION
In basis2 lemma, set-remove (which removes a single element) is used instead of set-subtract (which removes a set of elements). Previously, Picus gets away with this incorrect result because linear lemma will "clean up" afterward by syncing known set and unknown set. However, in the PR #18, we no longer do this syncing, thus uncovering this issue. This commit fixes the problem.