### PR TITLE
feat: support processing circom file directly

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -32,6 +32,28 @@ jobs:
         run: |
           grep "^# weak uniqueness: unsafe\.$" ./result.out
 
+  test-circom-mode:
+    runs-on: ubuntu-latest
+    container:
+      image: veridise/picus:git-latest
+    env:
+      PLTADDONDIR: /root/.local/share/racket/
+    steps:
+      - uses: actions/checkout@v1
+      - name: linking circom
+        run: ln -s /root/.cargo/bin/circom /usr/bin/circom
+      - name: run picus with z3, using v3
+        run: |
+          racket ./picus.rkt \
+              --solver z3 \
+              --circom ./benchmarks/circomlib-cff5ab6/Decoder@multiplexer.circom \
+              --weak | \
+            tee result.out
+        shell: bash # this ensures that pipefail is set
+      - name: test expected result
+        run: |
+          grep "^# weak uniqueness: unsafe\.$" ./result.out
+
   # run the full test for cvc5
   test-solve-with-cvc5:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This commit adds a capability to process circom files directly via the `--circom` flag. This is done by creating a temporary directory to store the compiled r1cs file. The temporary directory is cleaned up on exit when Picus exits normally. However, when Picus crashes or when it is interrupted, the temporary directory will not be cleaned, giving the user an opportunity to inspect files.

Additionally, `--opt-level` can be used to specify optimization level for circom compilation.