### PR TITLE
Use temporary directory more effectively

### DIFF
--- a/picus.rkt
+++ b/picus.rkt
@@ -18,6 +18,7 @@
 (define arg-r1cs #f)
 (define arg-circom #f)
 (define arg-opt-level #f)
+(define arg-clean? #t)
 (define arg-timeout 5000)
 (define arg-solver "z3")
 (define arg-selector "counter")
@@ -38,6 +39,8 @@
                (when (not (string-suffix? arg-circom ".circom"))
                  (tokamak:exit "file needs to be *.circom"))]
  #:once-each
+ [("--noclean") "do not clean up temporary files (default: false)"
+                (set! arg-clean? #f)]
  [("--opt-level") p-opt-level "optimization level for circom compilation (only applicable for --circom, default: 0)"
                   (set! arg-opt-level
                         (match p-opt-level
@@ -234,4 +237,5 @@
   (when (> arg-cex-verbose 0)
     (format-cex "other bindings" (order other-info))))
 
-(clean-tmpdir!)
+(when arg-clean?
+  (clean-tmpdir!))

--- a/picus/solvers/common.rkt
+++ b/picus/solvers/common.rkt
@@ -5,17 +5,17 @@
          racket/port
          racket/match
          racket/engine
+         racket/file
          (prefix-in tokamak: "../tokamak.rkt")
-         (prefix-in config: "../config.rkt"))
+         (prefix-in config: "../config.rkt")
+         "../tmpdir.rkt")
 
 (define ((make-solve #:executable executable
                      #:options [options '()])
          smt-str timeout #:verbose? [verbose? #f] #:output-smt? [output-smt? #f])
-  (define temp-folder (find-system-path 'temp-dir))
-  (define temp-file (format "picus~a.smt2"
-                            (string-replace (format "~a" (current-inexact-milliseconds)) "." "")))
-  (define temp-path (build-path temp-folder temp-file))
+  (define temp-path (make-temporary-file "picus~a.smt2" #:base-dir (get-tmpdir)))
   (with-output-to-file temp-path
+    #:exists 'replace
     (λ () (display smt-str)))
   (when (or verbose? output-smt?)
     (printf "(written to: ~a)\n" temp-path))

--- a/picus/tmpdir.rkt
+++ b/picus/tmpdir.rkt
@@ -1,0 +1,15 @@
+#lang racket/base
+
+(provide get-tmpdir
+         clean-tmpdir!)
+(require racket/file)
+
+(define tmpdir #f)
+
+(define (get-tmpdir)
+  (unless tmpdir
+    (set! tmpdir (make-temporary-directory "picus~a")))
+  tmpdir)
+
+(define (clean-tmpdir!)
+  (delete-directory/files tmpdir #:must-exist? #f))


### PR DESCRIPTION
Previously, Picus never cleans up smt2 files, and put them all in the top-level temporary directory, causing it to be cluttered with many Picus files.

This commit puts the generated smt2 files in a proper per-run temporary directory (introduced in #33), which by default will also get deleted afterward.

A separate commit adds an ability to retain the temporary files via `--noclean` in case the user wants to see the generated smt2 files for debugging purposes.