### PR TITLE
feat: support patching properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-benchmarks/**/patched-*
+benchmarks/**/*.patched.circom
 benchmarks/**/*.json
 benchmarks/**/*.sym
 benchmarks/**/*.r1cs

--- a/picus/global-inputs.rkt
+++ b/picus/global-inputs.rkt
@@ -1,13 +1,13 @@
 #lang racket/base
 
-(provide get-public-inputs)
+(provide get-global-inputs)
 
 (require racket/set
          racket/match
          csv-reading
          (prefix-in r1cs: "./r1cs/r1cs-grammar.rkt"))
 
-(define (get-public-inputs r1cs-path sym-path)
+(define (get-global-inputs r1cs-path sym-path)
   (define r0 (r1cs:read-r1cs r1cs-path))
   (define input-signals (r1cs:r1cs-inputs r0))
   (define ins (list->set input-signals))
@@ -24,9 +24,9 @@
 
 (module+ test
   (require rackunit)
-  (check-equal? (get-public-inputs "../benchmarks/circomlib-cff5ab6/AliasCheck@aliascheck.r1cs"
+  (check-equal? (get-global-inputs "../benchmarks/circomlib-cff5ab6/AliasCheck@aliascheck.r1cs"
                                    "../benchmarks/circomlib-cff5ab6/AliasCheck@aliascheck.sym")
                 (set "in"))
-  (check-equal? (get-public-inputs "../benchmarks/circomlib-cff5ab6/BabyAdd@babyjub.r1cs"
+  (check-equal? (get-global-inputs "../benchmarks/circomlib-cff5ab6/BabyAdd@babyjub.r1cs"
                                    "../benchmarks/circomlib-cff5ab6/BabyAdd@babyjub.sym")
                 (set "x1" "y1" "x2" "y2")))

--- a/tests/circomlib-test.rkt
+++ b/tests/circomlib-test.rkt
@@ -10,7 +10,7 @@
            racket/format
            racket/match
            rackunit
-           "../picus/public-inputs.rkt")
+           "../picus/global-inputs.rkt")
 
   (define filenames
     (command-line
@@ -68,7 +68,7 @@
       (cond
         [(has-public-input? orig-content) r1cs-path]
         [else
-         (define public-inputs (get-public-inputs r1cs-path sym-path))
+         (define public-inputs (get-global-inputs r1cs-path sym-path))
          (define patched-circom-path (get-full-path (format "patched-~a.circom" filename)))
          (define patched-r1cs-path (get-full-path (format "patched-~a.r1cs" filename)))
 


### PR DESCRIPTION
This PR consists of two commits.

- The first commit adds the patching feature properly via `--patch-circom`.
- The second commit switches the current tests to use this new flag.