### PR TITLE
fix: only remove tmpdir when tmpdir actually is created

### DIFF
--- a/picus/tmpdir.rkt
+++ b/picus/tmpdir.rkt
@@ -12,4 +12,5 @@
   tmpdir)
 
 (define (clean-tmpdir!)
-  (delete-directory/files tmpdir #:must-exist? #f))
+  (when tmpdir
+    (delete-directory/files tmpdir)))


### PR DESCRIPTION
It could be that tmpdir is never created, particularly in the --r1cs mode (so there is no circom compilation which requires tmpdir), and under the situation where propagation suffices for determining safety (so no need to call the solver => no need to create the smt2 file in the tmpdir). In such case, tmpdir is false, so Picus fails with a contract error. This commit fixes the problem.