### PR TITLE
ci: additionally check that Picus terminates properly

### DIFF
--- a/tests/circomlib-test.rkt
+++ b/tests/circomlib-test.rkt
@@ -81,7 +81,8 @@
           ['safe #px"(?m:^weak uniqueness: safe\\.$)"]
           ['unsafe #px"(?m:^weak uniqueness: unsafe\\.$)"]
           ['unknown #px"(?m:^weak uniqueness: unknown\\.$)"])
-        (get-output-string string-port))]
+        (get-output-string string-port))
+       (check-not-false timing-info)]
       ['timeout
        (check-false timing-info)])
     (flush))


### PR DESCRIPTION
This would have caught the mistake fixed in #38