### PR TITLE
Make --weak the default

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -24,8 +24,7 @@ jobs:
         run: |
           racket ./picus.rkt \
               --solver z3 \
-              --r1cs ./benchmarks/circomlib-cff5ab6/Decoder@multiplexer.r1cs \
-              --weak | \
+              --r1cs ./benchmarks/circomlib-cff5ab6/Decoder@multiplexer.r1cs | \
             tee result.out
         shell: bash # this ensures that pipefail is set
       - name: test expected result
@@ -46,8 +45,7 @@ jobs:
         run: |
           racket ./picus.rkt \
               --solver z3 \
-              --circom ./benchmarks/circomlib-cff5ab6/Decoder@multiplexer.circom \
-              --weak | \
+              --circom ./benchmarks/circomlib-cff5ab6/Decoder@multiplexer.circom | \
             tee result.out
         shell: bash # this ensures that pipefail is set
       - name: test expected result

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ This compiles all the "circomlib-utils" benchmarks, and won't throw any error if
 Then test some benchmarks, e.g., the `Decoder` benchmark, run:
 
 ```bash
-racket ./picus.rkt --solver cvc5 --timeout 5000 --weak --r1cs ./benchmarks/circomlib-cff5ab6/Decoder@multiplexer.r1cs
+racket ./picus.rkt --solver cvc5 --timeout 5000 --r1cs ./benchmarks/circomlib-cff5ab6/Decoder@multiplexer.r1cs
 ```
 
 A successful run will output logging info ***similar*** to the following (note that actual counter-example could be different due to potential stochastic search strategy in dependant libraries):
@@ -153,8 +153,16 @@ usage: picus.rkt [ <option> ... ]
 
 <option> is one of
 
-  --r1cs <p-r1cs>
-     path to target r1cs
+/ --r1cs <p-r1cs>
+|    path to target r1cs
+| --circom <p-circom>
+\    path to target circom (need circom compiler in PATH)
+  --noclean
+     do not clean up temporary files (default: false)
+  --patch-circom
+     patch circom file to add public inputs (only applicable for --circom, default: false)
+  --opt-level <p-opt-level>
+     optimization level for circom compilation (only applicable for --circom, default: 0)
   --timeout <p-timeout>
      timeout for every small query (default: 5000ms)
   --solver <p-solver>
@@ -165,12 +173,22 @@ usage: picus.rkt [ <option> ... ]
      path to precondition json (default: null)
   --noprop
      disable propagation (default: false / propagation on)
+  --nosolve
+     disable solver phase (default: false / solver on)
   --smt
      show path to generated smt files (default: false)
-  --weak
-     only check weak safety, not strong safety  (default: false)
-  --map
-     map the r1cs signals of model to its circom variable (default: true)
+  --strong
+     check for strong safety (default: false)
+  --verbose <verbose>
+     verbose level (default: 0)
+       0: not verbose; only display the final output
+       1: output algorithm computation, but display ... when the output is too large
+       2: output full algorithm computation
+  --cex-verbose <cex-verbose>
+     counterexample verbose level (default: 0)
+       0: not verbose; only output with circom variable format
+       1: output with circom variable format when applicable, and r1cs signal format otherwise
+       2: output with r1cs signal format
   --help, -h
      Show this help
   --

--- a/picus-solve.sh
+++ b/picus-solve.sh
@@ -11,4 +11,4 @@ otime=600
 solver=cvc5
 
 echo "# solving: ${fp}"
-timeout ${otime} racket ./picus.rkt --timeout 5000 --solver ${solver} --weak --r1cs ${fp} --map
+timeout ${otime} racket ./picus.rkt --timeout 5000 --solver ${solver} --r1cs ${fp} --map

--- a/picus.rkt
+++ b/picus.rkt
@@ -28,7 +28,7 @@
 (define arg-prop #t)
 (define arg-slv #t)
 (define arg-smt #f)
-(define arg-weak #f)
+(define arg-strong #f)
 (define arg-cex-verbose 0)
 (command-line
  #:once-any
@@ -66,8 +66,8 @@
                 (set! arg-slv #f)]
  [("--smt") "show path to generated smt files (default: false)"
             (set! arg-smt #t)]
- [("--weak") "only check weak safety, not strong safety  (default: false)"
-             (set! arg-weak #t)]
+ [("--strong") "check for strong safety (default: false)"
+               (set! arg-strong #t)]
  [("--verbose")
   verbose
   ["verbose level (default: 0)"
@@ -162,7 +162,7 @@
 (vprintf "propagation on: ~a\n" arg-prop)
 (vprintf "solver on: ~a\n" arg-slv)
 (vprintf "smt: ~a\n" arg-smt)
-(vprintf "weak: ~a\n" arg-weak)
+(vprintf "strong: ~a\n" arg-strong)
 (vprintf "cex-verbose: ~a\n" arg-cex-verbose)
 
 ; =================================================
@@ -192,7 +192,7 @@
 (define input-set (list->set input-list))
 (define output-list (r1cs:r1cs-outputs r0))
 (define output-set (list->set output-list))
-(define target-set (if arg-weak (list->set output-list) (list->set (range nwires))))
+(define target-set (if arg-strong (list->set (range nwires)) (list->set output-list)))
 (vprintf "inputs: ~e.\n" input-list)
 (vprintf "outputs: ~e.\n" output-list)
 (vprintf "targets: ~e.\n" target-set)
@@ -253,7 +253,7 @@
    solve interpret-r1cs
    optimize-r1cs-p0 expand-r1cs normalize-r1cs optimize-r1cs-p1))
 (vprintf "final unknown set ~e.\n" res-us)
-(printf "~a uniqueness: ~a.\n" (if arg-weak "weak" "strong") res)
+(printf "~a uniqueness: ~a.\n" (if arg-strong "strong" "weak") res)
 
 ;; format-cex :: string?, (listof (pairof string? any/c)), #:diff (listof (pairof string? any/c)) -> void?
 (define (format-cex heading info #:diff [diff info])

--- a/scripts/batch-run-picus-noprop.sh
+++ b/scripts/batch-run-picus-noprop.sh
@@ -18,7 +18,7 @@ do
 	echo "====   start: $(date -u)"
 	st="$(date -u +%s)"
 
-    timeout ${otime} racket ./picus.rkt --timeout 5000 --solver ${solver} --weak --noprop --r1cs ${fp} > ${logpath}/${bn}.log 2>&1
+    timeout ${otime} racket ./picus.rkt --timeout 5000 --solver ${solver} --noprop --r1cs ${fp} > ${logpath}/${bn}.log 2>&1
 
 	et="$(date -u +%s)"
 	echo "====     end: $(date -u)"

--- a/scripts/batch-run-picus-nosolve.sh
+++ b/scripts/batch-run-picus-nosolve.sh
@@ -18,7 +18,7 @@ do
 	echo "====   start: $(date -u)"
 	st="$(date -u +%s)"
 
-    timeout ${otime} racket ./picus.rkt --timeout 5000 --solver ${solver} --weak --nosolve --r1cs ${fp} > ${logpath}/${bn}.log 2>&1
+    timeout ${otime} racket ./picus.rkt --timeout 5000 --solver ${solver} --nosolve --r1cs ${fp} > ${logpath}/${bn}.log 2>&1
 
 	et="$(date -u +%s)"
 	echo "====     end: $(date -u)"

--- a/scripts/batch-run-picus-pre.sh
+++ b/scripts/batch-run-picus-pre.sh
@@ -19,7 +19,7 @@ do
 	echo "====   start: $(date -u)"
 	st="$(date -u +%s)"
 
-	timeout ${otime} racket ./picus.rkt --timeout 5000 --solver ${solver} --weak --r1cs ${fp} --precondition ${prefolder}/${bn}.pre.json > ${logpath}/${bn}.log 2>&1
+	timeout ${otime} racket ./picus.rkt --timeout 5000 --solver ${solver} --r1cs ${fp} --precondition ${prefolder}/${bn}.pre.json > ${logpath}/${bn}.log 2>&1
 	
 	et="$(date -u +%s)"
 	echo "====     end: $(date -u)"

--- a/scripts/batch-run-picus.sh
+++ b/scripts/batch-run-picus.sh
@@ -18,7 +18,7 @@ do
 	echo "====   start: $(date -u)"
 	st="$(date -u +%s)"
 
-    timeout ${otime} racket ./picus.rkt --timeout 5000 --solver ${solver} --weak --r1cs ${fp} > ${logpath}/${bn}.log 2>&1
+    timeout ${otime} racket ./picus.rkt --timeout 5000 --solver ${solver} --r1cs ${fp} > ${logpath}/${bn}.log 2>&1
 
 	et="$(date -u +%s)"
 	echo "====     end: $(date -u)"

--- a/tests/circomlib-test.rkt
+++ b/tests/circomlib-test.rkt
@@ -45,7 +45,6 @@
                    [current-command-line-arguments
                     (vector "--solver" "cvc5"
                             "--timeout" "5000"
-                            "--weak"
                             "--verbose" "1"
                             "--circom" (~a (build-path
                                             benchmark-dir


### PR DESCRIPTION
We almost always only want the weak safety (checking that output signals of the main component are deterministic), not strong safety (checking that all signals are deterministic). However, currently the strong safety mode is the default. This makes it cumbersome to invoke Picus, since we need to indicate that we want the weak safety explicitly.

This commit inverts the behavior by removing the flag `--weak` and adds the flag `--strong` (for strong safety), which is defaulted to false.