### PR TITLE
Do not show Circom's output in --verbose 0

### DIFF
--- a/picus.rkt
+++ b/picus.rkt
@@ -96,10 +96,23 @@
 (unless (implies arg-patch? arg-circom)
   (tokamak:exit "--patch-circom only applicable for --circom"))
 
+(define (callsys cmd . args)
+  (match (get-verbose)
+    [0
+     (define outp (open-output-string))
+     (define ret-status
+       (parameterize ([current-output-port outp]
+                      [current-error-port outp])
+         (apply system* cmd args)))
+     (unless ret-status
+       (display (get-output-string outp)))
+     ret-status]
+    [_ (apply system* cmd args)]))
+
 ;; compile-circom :: path? -> path?
 ;; compile circom file to r1cs file
 (define (compile-circom circom-path)
-  (unless (system* (find-executable-path "circom")
+  (unless (callsys (find-executable-path "circom")
                    "-o"
                    (get-tmpdir)
                    "--r1cs"

--- a/picus/verbose.rkt
+++ b/picus/verbose.rkt
@@ -1,12 +1,15 @@
 #lang racket/base
 
 (provide vprintf
+         get-verbose
          set-verbose!)
 
 (require racket/string
          racket/match)
 
 (define verbose 0)
+(define (get-verbose)
+  verbose)
 (define (set-verbose! v)
   (set! verbose v))
 


### PR DESCRIPTION
Unless the exit code is not 0.