### PR TITLE
feat: framework for SaaS

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -52,7 +52,7 @@ jobs:
       - name: run picus with cvc5, using v3
         run: raco test ++args "--parallel ${{ matrix.id }} 4" ./tests/circomlib-test.rkt
 
-  performance-test:
+  misc-test:
     runs-on: ubuntu-latest
     container:
       image: veridise/picus:git-latest
@@ -61,10 +61,12 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: run tests
-        run: raco test ./tests/performance-test.rkt
+        run: |
+          raco test ./tests/performance-test.rkt
+          raco test ./tests/framework-test.rkt
 
   publish-docker:
-    needs: [configuration-test, main-test, performance-test]
+    needs: [configuration-test, main-test, misc-test]
     name: "Publish Docker image to DockerHub"
     if: github.event_name == 'push'
     runs-on: ubuntu-latest

--- a/picus/exit.rkt
+++ b/picus/exit.rkt
@@ -1,0 +1,45 @@
+#lang racket/base
+
+(provide picus:exit
+         exit-code:success
+         exit-code:issues
+         exit-code:tool-failure
+         exit-code:tool-error
+         exit-code:user-error
+
+         picus:user-error
+         picus:tool-error)
+
+(require "logging.rkt")
+
+;; HACK: sleep allows Racket to flush log output before exiting
+;; See https://github.com/racket/racket/issues/4773
+(define (picus:exit code)
+  (picus:log-info "Exiting Picus with the code ~a" code)
+  (sleep 0.1)
+  (exit code))
+
+;; exits normally
+(define exit-code:success 0)
+
+;; exits with issues
+(define exit-code:issues 9)
+
+;; exits with tool failure (e.g., uncaught exception)
+(define exit-code:tool-failure 1)
+
+;; exits with tool error (e.g., internal error, or unreachable path reached)
+(define exit-code:tool-error 10)
+
+;; exits with user error (e.g., bad inputs)
+(define exit-code:user-error 50)
+
+(define/caller (picus:user-error fmt . args) #:caller caller
+  (picus:log-error (apply format fmt args)
+                   #:extra (hash 'caller caller))
+  (picus:exit exit-code:user-error))
+
+(define/caller (picus:tool-error fmt . args) #:caller caller
+  (picus:log-error (apply format fmt args)
+                   #:extra (hash 'caller caller))
+  (picus:exit exit-code:tool-error))

--- a/picus/framework.rkt
+++ b/picus/framework.rkt
@@ -1,0 +1,135 @@
+
+#lang racket/base
+
+(require racket/logging
+         racket/match
+         racket/hash
+         racket/date
+         json
+         "logging.rkt"
+         "exit.rkt")
+
+(provide with-framework)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; printing functions
+
+(define (should-display? level)
+  (>= (get-level level) (get-level (current-level))))
+
+;; Everything above the warning level should be logged to stderr
+(define (to-stderr? level)
+  (>= (get-level level) (get-level level:warning)))
+
+;; print-json has the following characteristics
+;; (1) It completely disregards current-level
+;;     (that is, it doesn't call should-display? at all)
+;;     because there is already a service to filter JSON information
+;; (2) It ignores the message field, since msg key already contains the message.
+;; (3) It only uses current-outp.
+(define (print-json #:level level
+                    #:message _message
+                    #:data data
+                    #:timestamp timestamp)
+  (define outp (current-outp))
+  (write-json (hash-union data
+                          (hash 'timestamp timestamp
+                                'level level
+                                'logger_name "picus")
+                          #:combine (λ (left _right) left))
+              outp)
+  (newline outp))
+
+;; print-text has the following characeteristics
+;; (1) It ignores the data field, since it is usually too verbose to
+;;     print the data. This includes the msg key in the data field,
+;;     which is for JSON logging.
+(define (print-text #:level level
+                    #:message message
+                    #:data _data
+                    #:timestamp timestamp)
+  (when (should-display? level)
+    (displayln message (if (to-stderr? level) (current-errp) (current-outp)))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Parameters
+
+(define current-outp (make-parameter (current-output-port)))
+(define current-errp (make-parameter (current-error-port)))
+(define current-level (make-parameter 'info))
+(define current-printer (make-parameter print-text))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Parameters
+
+;; hash-pop :: hash? any/c #:default (or/c #f (-> any/c)) -> (values any/c hash?)
+;; Pops the key. In case the key is not present, returns the default value when
+;; default is a thunk. Otherwise, when default is #f (which is the default),
+;; raises an error.
+(define (hash-pop ht key #:default [default #f])
+  (values (if default
+              (hash-ref ht key default)
+              (hash-ref ht key))
+          (hash-remove ht key)))
+
+(define (framework:core proc)
+  (with-intercepted-logging
+    (λ (l)
+      (match-define (vector _ message data _) l)
+      (define-values (level data*) (hash-pop data 'level))
+      ((current-printer)
+       #:level level
+       #:message message
+       #:data data*
+       #:timestamp (parameterize ([date-display-format 'iso-8601])
+                     (date->string (current-date) #t))))
+    (λ ()
+      (with-handlers ([exn:fail? (λ (e)
+                                   (picus:log-exception e)
+                                   (picus:exit exit-code:tool-failure))])
+        (proc))
+      (picus:exit exit-code:success))
+    #:logger picus-logger
+    'debug ; debug is the lowest level of logging, so this intercepts everything
+    #f))
+
+;; with-framework :: #:out (or/c output-port? path-string?) = (current-output-port)
+;;                   #:err (or/c output-port? path-string? 'out) = (current-error-port)
+;;                   #:json? boolean?
+;;                   #:truncate? boolean?
+;;                   #:level string?
+;;                   (-> any)
+;;                   ->
+;;                   never
+;; Note that if #:err is the same as #:out, then 'out should be given.
+;; so that we avoid (potentially) opening the same file twice.
+(define (with-framework
+          #:json? json?
+          #:truncate? truncate?
+          #:level level
+          #:out [out (current-output-port)]
+          #:err [err (current-error-port)]
+          proc)
+  (let loop ([out out] [err err])
+    (cond
+      ;; configure out
+      [(path-string? out)
+       (call-with-output-file* out
+         #:exists 'truncate
+         (λ (outp) (loop outp err)))]
+
+      ;; configure err
+      [(path-string? err)
+       (call-with-output-file* err
+         #:exists 'truncate
+         (λ (errp) (loop out errp)))]
+      [(eq? 'out err) (loop out out)]
+
+      ;; main
+      [else
+       (parameterize ([current-outp out]
+                      [current-errp err]
+                      [current-truncate? truncate?]
+                      [current-printer (if json? print-json print-text)]
+                      [current-level level])
+         (framework:core proc))])))

--- a/picus/logging.rkt
+++ b/picus/logging.rkt
@@ -1,0 +1,170 @@
+;; This module creates a middleware for logging.
+;; We want to reuse Racket's logging facility, since it already handles
+;; difficult parts like logging in the presence of concurrency.
+;; On the other hand, the logging facility is limited, and doesn't work well with
+;; the protocol that we are targeting. So we need to create this bridge.
+;;
+;; In particular, the middleware introduces Picus logging level,
+;; which does not need to agree with Racket logging level.
+;; This is so that we are able to create custom levels, as Racket's logging has
+;; fixed levels.
+;;
+;; The data field must always contain these keys:
+;; - msg: the message to be logged for JSON logging
+;; - level: the Picus's logging level
+;; - caller: the source location of the log call.
+;;     Racket does not have an information about the caller name,
+;;     so the srcloc won't have the function name.
+;;
+;; The message field itself is used for text logging.
+;; Usually, the message field and the msg key under the data field
+;; would be identical, but they can also diverge if needed.
+
+#lang racket/base
+
+
+(provide define-log-function
+         define-picus-level
+
+         get-level
+         get-levels
+
+         picus-logger
+         current-truncate?
+
+         picus:log-debug
+         picus:log-info
+         picus:log-warning
+         picus:log-error
+         picus:log-critical
+
+         picus:log-exception
+
+         level:debug
+         level:info
+         level:warning
+         level:error
+         level:critical
+
+         ;; non-standard level
+         picus:log-main
+         picus:log-progress
+
+         define/caller)
+
+(require racket/hash
+         racket/exn
+         racket/string
+         syntax/parse/define
+         (for-syntax racket/base
+                     racket/syntax))
+
+(define-logger picus)
+
+(define current-truncate? (make-parameter #t))
+
+(define (do-truncate fmt)
+  (if (current-truncate?)
+      fmt
+      (string-replace fmt "~e" "~a")))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Logging level definer
+
+(define levels (make-hash))
+
+(define (get-level level)
+  (hash-ref levels level #f))
+
+(define (get-levels)
+  (map car (sort (hash->list levels) < #:key cdr)))
+
+;; (define-picus-level picus-level level) defines a new Picus log level.
+;; The level name is in upppercase
+(define-syntax-parse-rule (define-picus-level picus-level:id level:integer)
+  #:with level-str (string-upcase (symbol->string (syntax-e #'picus-level)))
+  #:with level-id (format-id #'picus-level "level:~a" #'picus-level)
+  (begin
+    (define level-id 'level-str)
+    (hash-set! levels level-id level)))
+
+;; (define-log-function name [#:picus picus-level] [#:rkt rkt-level])
+;; defines a new logging function `name`.
+;; This logging function has the Picus logging level `picus-level`
+;; and the Racket logging level `rkt-level`.
+;; By default, both `picus-level` and `rkt-level` are defaulted to `name`.
+;;
+;; The macro binds `picus:log-<name>` to a logging function (actually a macro).
+;; `picus:log-<name>` accepts a format string, followed by arguments to the format.
+;; A combination of the format string and arguments are used for JSON logging.
+;; The keyword argument #:extra can be used to pass an additional hash table
+;; that contains extra information.
+;; The keyword argument #:text-msg is similar to the format string,
+;; and it is used for the text logging. By default, #:text-msg is defaulted to msg.
+;;
+;; The format string should use ~e for argument values that are truncatable
+;; When current-truncate? is false, the full value is printed.
+;; But when current-truncate? is true, the value is truncated.
+(define-syntax-parse-rule (define-log-function name:id
+                            {~optional {~seq #:picus picus-level:id}
+                                       #:defaults ([picus-level #'name])}
+                            {~optional {~seq #:rkt rkt-level:id}
+                                       #:defaults ([rkt-level #'name])})
+  #:fail-unless
+  (member (syntax-e #'rkt-level) '(debug info warning error fatal none))
+  "Racket's log level must be one of: debug, info, warning, error, fatal, and none"
+
+  #:with level-id (format-id #'picus-level "level:~a" #'picus-level)
+
+  #:with picus-log-id (format-id #'name "picus:log-~a" #'name)
+  (define/caller (picus-log-id text-msg #:extra [extra (hash)] #:json-msg [json-msg text-msg] . args)
+    #:caller caller
+    (log-message picus-logger
+                 'rkt-level
+                 (logger-name picus-logger)
+                 (apply format (do-truncate text-msg) args)
+                 ;; prefer the user's extra over framework's information
+                 ;; since we want the user to be able to override the information
+                 (hash-union extra (hash 'caller caller
+                                         'level level-id
+                                         'msg (apply format (do-truncate json-msg) args))
+                             #:combine (λ (left _right) left))
+                 #f)))
+
+(define-syntax-parse-rule (define/caller (name:id . args) #:caller caller:id body ...+)
+  (begin
+    (define (internal-fun #:caller caller . args)
+      body ...)
+    (define-syntax-parse-rule (name . inner-args)
+      #:do [(define src (syntax-source this-syntax))
+            (define line (syntax-line this-syntax))
+            (define column (syntax-column this-syntax))]
+      #:with caller-lit (format "~a:~a:~a" src line column)
+      (internal-fun #:caller 'caller-lit . inner-args))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Built-in logging levels
+
+(define-picus-level debug 10)
+(define-picus-level info 20)
+(define-picus-level warning 30)
+(define-picus-level error 40)
+(define-picus-level critical 50)
+
+;; custom level: progress
+(define-picus-level progress 15)
+
+;; from https://docs.python.org/3/library/logging.html#logging-levels
+(define-log-function debug)
+(define-log-function info)
+(define-log-function warning)
+(define-log-function error)
+(define-log-function critical #:rkt fatal)
+
+;; This is for the main output.
+(define-log-function main #:picus info #:rkt info)
+;; This is for the algorithm progress.
+(define-log-function progress #:rkt debug)
+
+(define/caller (picus:log-exception e) #:caller caller
+  (picus:log-error "~e" (exn->string e) #:extra (hash 'caller caller)))

--- a/tests/framework-test.rkt
+++ b/tests/framework-test.rkt
@@ -1,0 +1,123 @@
+#lang racket/base
+
+(require racket/list
+         syntax/parse/define
+         rackunit
+         json
+         "../picus/framework.rkt"
+         "../picus/exit.rkt"
+         "../picus/logging.rkt")
+
+(define-syntax-parse-rule (run-test
+                           #:setup
+                           setup-body ...+
+                           #:check-status code
+                           check-status-body ...+
+                           #:check out:id err:id
+                           check-body ...+)
+
+  (let ([out-id (open-output-string)]
+        [err-id (open-output-string)])
+    (parameterize ([current-output-port out-id]
+                   [current-error-port err-id])
+      (let/cc return
+        (parameterize ([exit-handler (λ (code)
+                                       check-status-body ...
+                                       (return #f))])
+          setup-body ...)))
+    (let ([out (get-output-string out-id)]
+          [err (get-output-string err-id)])
+      check-body ...)))
+
+(test-case "test log level in text mode (partial log)"
+  (run-test
+   #:setup
+   (with-framework
+     #:json? #f
+     #:truncate? #f
+     #:level "ERROR"
+     (λ ()
+       (picus:log-error "foo")
+       (picus:log-info "bar")))
+
+   #:check-status code
+   (check-equal? code 0)
+
+   #:check out err
+   (check-equal? out "")
+   (check-regexp-match #px"foo" err)))
+
+(test-case "test log level in text mode (full log)"
+  (run-test
+   #:setup
+   (with-framework
+     #:json? #f
+     #:truncate? #f
+     #:level "INFO"
+     (λ ()
+       (picus:log-error "foo")
+       (picus:log-info "bar")))
+
+   #:check-status code
+   (check-equal? code 0)
+
+   #:check out err
+   (check-regexp-match #px"bar" out)
+   (check-regexp-match #px"foo" err)))
+
+(test-case "test log level in json mode"
+  (run-test
+   #:setup
+   (with-framework
+     #:json? #t
+     #:truncate? #f
+     #:level #f
+     (λ ()
+       (picus:log-error "foo")
+       (picus:log-info "bar")))
+
+   #:check-status code
+   (check-equal? code 0)
+
+   #:check out err
+   (check-equal? err "")
+
+   (define jsons (for/list ([json (in-port read-json (open-input-string out))]) json))
+
+   ;; log-error
+   (define json-err (first jsons))
+   (check-regexp-match #px"framework-test\\.rkt:76:7" (hash-ref json-err 'caller))
+   (check-equal? (hash-ref json-err 'level) "ERROR")
+   (check-equal? (hash-ref json-err 'msg) "foo")
+
+   ;; log-info
+   (define json-info (second jsons))
+   (check-regexp-match #px"framework-test\\.rkt:77:7" (hash-ref json-info 'caller))
+   (check-equal? (hash-ref json-info 'level) "INFO")
+   (check-equal? (hash-ref json-info 'msg) "bar")
+
+   ;; exit-info
+   (define json-exit (third jsons))
+   (check-regexp-match #px"exit\\.rkt:18:2" (hash-ref json-exit 'caller))
+   (check-equal? (hash-ref json-exit 'level) "INFO")
+   (check-equal? (hash-ref json-exit 'msg) "Exiting Picus with the code 0")))
+
+(test-case "test exit code"
+  (run-test
+   #:setup
+   (with-framework
+     #:json? #f
+     #:truncate? #f
+     #:level "INFO"
+     (λ ()
+       (picus:log-error "foo")
+       (picus:tool-error "bad")
+       (picus:log-info "bar")))
+
+   #:check-status code
+   (check-equal? code exit-code:tool-error)
+
+   #:check out err
+   ;; control not reached log-info
+   (check-false (regexp-match #px"bar" out))
+   (check-regexp-match #px"foo" err)))


### PR DESCRIPTION
This commit adds a framework for logging and exiting in a way that conforms to the SaaS requirement. Logging in particular could be done in either the JSON mode or the text mode.
The main entry point to the framework is the `with-framework` function.

This commit does not yet switch Picus to use the framework. That will be done in a separate commit.
See `framework-test.rkt` for tests of the framework.