### PR TITLE
docker: build compiled files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+**/compiled
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,5 @@ FROM veridise/picus:base
 COPY ./ /Picus/
 
 WORKDIR /Picus/
+RUN raco make picus.rkt
 CMD [ "/bin/bash" ]


### PR DESCRIPTION
When built locally, Picus often fails to run due to the mismatch of the compiled files in the newer, local Racket version, and the older, image-based Racket version. This commit fixes the issue.