### PR TITLE
ci: only run amd64 for now

### DIFF
--- a/.github/workflows/docker-base.yml
+++ b/.github/workflows/docker-base.yml
@@ -18,5 +18,5 @@ jobs:
         with:
           push: true
           file: resources/Dockerfile@base
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64
           tags: veridise/picus:base

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -114,5 +114,5 @@ jobs:
         with:
           push: true
           file: Dockerfile
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64
           tags: veridise/picus:git-latest, veridise/picus:git-${{ github.sha }}


### PR DESCRIPTION
CoCoA wasn't successfully compiled on arm64 for some reasons. See
https://github.com/Veridise/Picus/actions/runs/6483965862/job/17606717211#step:4:15460. So we disable arm64 target for now.