### PR TITLE
docker: do not copy benchmarks dir

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 **/compiled
 .git
+benchmarks/


### PR DESCRIPTION
This should help making the Docker image a bit smaller.